### PR TITLE
fix(umbrella): make scitex.ml/scitex.genai canonical, scitex.ai legacy

### DIFF
--- a/src/scitex/__init__.py
+++ b/src/scitex/__init__.py
@@ -206,7 +206,8 @@ class _CallableModuleWrapper:
 # (and submodule imports like `from scitex.<short>.<sub> import Y`) resolve to the
 # external package without requiring a `src/scitex/<short>/` directory in this repo.
 _EXTERNAL_REEXPORTS = {
-    "ai": "scitex_ai",
+    "ml": "scitex_ml",
+    "genai": "scitex_genai",
     "etc": "scitex_etc",
     "gists": "scitex_gists",
     "audit": "scitex_audit",
@@ -263,23 +264,22 @@ for _short, _ext in _EXTERNAL_REEXPORTS.items():
         # Hard-missing — friendly install hint via the __getattr__ proxy below.
         pass
 
-# Deprecated module aliases. All four (`ml`, `verify`, `reproduce`, `rng`)
-# are handled by tiny shim directories at `src/scitex/{ml,verify,reproduce,
-# rng}/__init__.py` so:
-#   1. `import scitex.<alias>` keeps working (Python finds the dir).
-#   2. The DeprecationWarning fires only when the deprecated path is
-#      actually used (not on every `import scitex`).
-#   3. We avoid eager in-tree imports here — those can trigger circular
-#      imports when the canonical leaf transitively reaches back into the
-#      umbrella (`scitex.plt`, `scitex.config`, etc.).
-# See also `__getattr__` below — that catches `getattr(scitex, "ml")` too.
+# Deprecated module aliases (`ai`, `verify`, `reproduce`, `rng`) are resolved
+# lazily via `__getattr__` below: the DeprecationWarning fires only when the
+# deprecated path is actually accessed (not on every `import scitex`), and we
+# avoid eager in-tree imports that could trigger circular imports.
+#
+# `ai` is the legacy name for what is now split into the canonical `ml`
+# (classical/deep ML — scitex_ml) and `genai` (generative-AI providers —
+# scitex_genai). `scitex.ai` redirects to `scitex.ml`.
 
 
 # Create lazy modules
 io = _LazyModule("io")
 gen = _LazyModule("gen")
 plt = _LazyModule("plt")
-ai = _LazyModule("ai", external="scitex_ai")
+ml = _LazyModule("ml", external="scitex_ml")
+genai = _LazyModule("genai", external="scitex_genai")
 pd = _LazyModule("pd")
 str = _LazyModule("str", external="scitex_str")
 stats = _LazyModule("stats")
@@ -365,7 +365,7 @@ usage._setup_persistence("scitex", "usage")
 # can be deleted. Each access emits a DeprecationWarning and returns the
 # canonical lazy module.
 _DEPRECATED_MODULE_ALIASES = {
-    "ml": "ai",
+    "ai": "ml",
     "reproduce": "repro",
     "rng": "repro",
     "verify": "clew",
@@ -433,7 +433,8 @@ __all__ = [
     "io",
     "gen",
     "plt",
-    "ai",
+    "ml",
+    "genai",
     "pd",
     "str",
     "stats",

--- a/tests/custom/test_imports.py
+++ b/tests/custom/test_imports.py
@@ -184,9 +184,6 @@ SKIP_MODULES = {
     "scitex.ml",  # Optional ML dependencies
     "scitex.nn",  # torch docstring compatibility issue
     "scitex.session.template",  # Module object not callable issue
-    "scitex.ai.optim.Ranger_Deep_Learning_Optimizer.setup",  # noqa: E501
-    "scitex.ai.sk",  # Deprecated/missing module
-    "scitex.ai.sklearn.clf",  # Deprecated/missing module
 }
 
 # Module patterns to skip

--- a/tests/scitex/test_subset_identity_peers.py
+++ b/tests/scitex/test_subset_identity_peers.py
@@ -40,7 +40,6 @@ PEERS: list = [  # list[tuple[str, str] | pytest.ParameterSet]
     ("scitex_logging", "scitex.logging"),
     ("scitex_datetime", "scitex.dt"),
     ("scitex_ml", "scitex.ml"),
-    ("scitex_ai", "scitex.ai"),
     ("scitex_writer", "scitex.writer"),
     ("scitex_repro", "scitex.repro"),
     ("scitex_session", "scitex.session"),


### PR DESCRIPTION
The umbrella had the rename direction reversed: `scitex.ai` was wired as canonical (`external=scitex_ai`, a package that no longer exists), while the new `scitex.ml` was demoted to a deprecated alias pointing back at it. So `scitex.ml.X` wrongly warned *"use scitex.ai instead"* and resolved to the missing `scitex_ai`.

Actual history: `scitex.ai` → standalone `scitex-ai` → renamed `scitex-ml` (+ `scitex-genai` split out). This wires `ml → scitex_ml` and `genai → scitex_genai` as canonical lazy re-exports and redirects legacy `ai → ml` with a DeprecationWarning.

- `_EXTERNAL_REEXPORTS`: `ai/scitex_ai` → `ml/scitex_ml` + `genai/scitex_genai`
- lazy modules: `ai` → `ml` + `genai`
- `_DEPRECATED_MODULE_ALIASES`: `"ml":"ai"` → `"ai":"ml"`
- `__all__`: `ai` → `ml` + `genai`
- tests: drop the deleted `scitex_ai` identity peer; drop dead `scitex.ai.*` skips

Verified: `scitex.ml.*` clean (no warning); `scitex.genai` resolves; `scitex.ai` warns "use scitex.ml instead" and is `scitex.ml`; `from scitex.ml import X` and `import scitex.ml` both resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)