### PR TITLE
fix(ci,ps168): cla.yml secret -> GH_PERSONAL_ACCESS_TOKEN

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,7 +20,7 @@ jobs:
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PERSONAL_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: "signatures/cla.json"
           path-to-document: "https://github.com/ywatanabe1989/scitex-dev/blob/main/CLA.md"


### PR DESCRIPTION
Final piece of the ecosystem-wide CLA PAT secret rename. This branch (main) couldn't be direct-pushed (branch protection or repository ruleset), so the same one-line flip that the lead's god-token patched directly on 57 other branches goes through PR here instead.

Once this merges, phase 3 (delete old PERSONAL_ACCESS_TOKEN + CLA_PERSONAL_ACCESS_TOKEN ecosystem-wide) fires.