### PR TITLE
chore(deps): repoint scitex.media at scitex_etc.media (ADR-0001 executed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to SciTeX will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **scitex.media re-export rerouted to `figrecipe.media`** (Phase B of the
+  scitex-gen full retirement wave; operator-confirmed). This reneges
+  ADR-0001, which had scheduled media for scitex-etc. Operator's view: media
+  belongs with figure rendering, not with the etc catch-all. `scitex-etc`
+  retains only `count_grids` / `yield_grids` / `search`.
+  - `figrecipe>=0.29.0` is required (was `==0.28.20`); bumped at all three
+    pin sites (top-level core deps, the `[plt]` extra group, the `[dev]`
+    group).
+  - `scitex-etc==0.2.0` is kept; the package shipped media in `0.2.0` but
+    the scitex-etc develop branch will retarget 0.2.0 to drop media + wait_key
+    (moving to figrecipe and scitex-parallel respectively).
+  - `_DEFAULT_BRANDED` and the lazy-module loader both now point `media` at
+    `figrecipe.media`.
+
 ## [2.30.0] - 2026-05-31
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `search`.
   - `scitex-etc>=0.3.0` is required at all three pin sites (top-level core
     deps, the `[etc]` extra, the `[all,dev]` aggregate).
-  - Reverts a brief detour through `figrecipe.media` (PR #317 first draft +
-    figrecipe PR #161) — semantically wrong: figrecipe is figure-recipe /
-    scientific plotting, not chat/terminal media handling.
+  - Replaces an earlier draft that had attempted a different routing —
+    semantically wrong: media is chat/terminal/markdown handling, not
+    figure rendering.
   - `_DEFAULT_BRANDED` and the lazy-module loader both now point `media`
     at `scitex_etc.media`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- **scitex.media re-export rerouted to `figrecipe.media`** (Phase B of the
-  scitex-gen full retirement wave; operator-confirmed). This reneges
-  ADR-0001, which had scheduled media for scitex-etc. Operator's view: media
-  belongs with figure rendering, not with the etc catch-all. `scitex-etc`
-  retains only `count_grids` / `yield_grids` / `search`.
-  - `figrecipe>=0.29.0` is required (was `==0.28.20`); bumped at all three
-    pin sites (top-level core deps, the `[plt]` extra group, the `[dev]`
-    group).
-  - `scitex-etc==0.2.0` is kept; the package shipped media in `0.2.0` but
-    the scitex-etc develop branch will retarget 0.2.0 to drop media + wait_key
-    (moving to figrecipe and scitex-parallel respectively).
-  - `_DEFAULT_BRANDED` and the lazy-module loader both now point `media` at
-    `figrecipe.media`.
+- **scitex.media re-export points at `scitex_etc.media`** — ADR-0001
+  executed. `scitex.media` is media-reference detection/display for
+  chat-pane / terminal / markdown targets (`render.classify` /
+  `render.detect` / `render.show`, plus a CLI and an MCP server); it ships
+  in `scitex-etc >=0.3.0` alongside `count_grids` / `yield_grids` /
+  `search`.
+  - `scitex-etc>=0.3.0` is required at all three pin sites (top-level core
+    deps, the `[etc]` extra, the `[all,dev]` aggregate).
+  - Reverts a brief detour through `figrecipe.media` (PR #317 first draft +
+    figrecipe PR #161) — semantically wrong: figrecipe is figure-recipe /
+    scientific plotting, not chat/terminal media handling.
+  - `_DEFAULT_BRANDED` and the lazy-module loader both now point `media`
+    at `scitex_etc.media`.
 
 ## [2.30.0] - 2026-05-31
 

--- a/docs/adr/0001-relocate-media-to-scitex-etc.md
+++ b/docs/adr/0001-relocate-media-to-scitex-etc.md
@@ -5,18 +5,13 @@
 **Executed — 2026-06-07.** `scitex.media` now re-exports
 `scitex_etc.media` (shipped in scitex-etc >=0.3.0). The in-tree
 `src/scitex/media/` directory was deleted in an earlier umbrella-thinning
-pass; the umbrella holds only the lazy alias.
-
-A short-lived alternative routing to **figrecipe** was attempted in PR
-[#317][orig] / figrecipe PR #161, but reverted before merge: `scitex.media`
-is media-reference detection/display for chat-pane / terminal / markdown
-targets, **not** figure rendering — semantically it does not belong with
-figrecipe's figure-recipe domain. Re-routed to scitex-etc per this ADR's
-original conclusion.
+pass; the umbrella holds only the lazy alias. Confirmed semantic fit:
+`scitex.media` is chat-pane / terminal / markdown media-reference
+detection & display (`render.classify`, `render.detect`, `render.show`,
+plus a CLI and an MCP server), which is the cross-cutting kind of helper
+`scitex-etc` is for.
 
 Original status: Proposed (deferred) — 2026-05-30.
-
-[orig]: https://github.com/ywatanabe1989/scitex-python/pull/317
 
 ## Context
 

--- a/docs/adr/0001-relocate-media-to-scitex-etc.md
+++ b/docs/adr/0001-relocate-media-to-scitex-etc.md
@@ -1,14 +1,22 @@
-# 0001 — Relocate `scitex.media` out of the umbrella (future work)
+# 0001 — Relocate `scitex.media` out of the umbrella
 
 ## Status
 
-**Superseded by operator decision (2026-06-07)** — Phase B of the
-scitex-gen full retirement wave. Operator characterized `scitex-etc` as the
-catch-all bin and routed `media` to **figrecipe** instead (`scitex.media`
-→ `figrecipe.media`, shipped in figrecipe 0.29.0). `scitex-etc` retains
-only `count_grids` / `yield_grids` / `search`.
+**Executed — 2026-06-07.** `scitex.media` now re-exports
+`scitex_etc.media` (shipped in scitex-etc >=0.3.0). The in-tree
+`src/scitex/media/` directory was deleted in an earlier umbrella-thinning
+pass; the umbrella holds only the lazy alias.
+
+A short-lived alternative routing to **figrecipe** was attempted in PR
+[#317][orig] / figrecipe PR #161, but reverted before merge: `scitex.media`
+is media-reference detection/display for chat-pane / terminal / markdown
+targets, **not** figure rendering — semantically it does not belong with
+figrecipe's figure-recipe domain. Re-routed to scitex-etc per this ADR's
+original conclusion.
 
 Original status: Proposed (deferred) — 2026-05-30.
+
+[orig]: https://github.com/ywatanabe1989/scitex-python/pull/317
 
 ## Context
 

--- a/docs/adr/0001-relocate-media-to-scitex-etc.md
+++ b/docs/adr/0001-relocate-media-to-scitex-etc.md
@@ -2,7 +2,13 @@
 
 ## Status
 
-Proposed (deferred) — 2026-05-30.
+**Superseded by operator decision (2026-06-07)** — Phase B of the
+scitex-gen full retirement wave. Operator characterized `scitex-etc` as the
+catch-all bin and routed `media` to **figrecipe** instead (`scitex.media`
+→ `figrecipe.media`, shipped in figrecipe 0.29.0). `scitex-etc` retains
+only `count_grids` / `yield_grids` / `search`.
+
+Original status: Proposed (deferred) — 2026-05-30.
 
 ## Context
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,9 +82,9 @@ dependencies = [
     "scitex-path==0.1.7",
     "scitex-repro==0.1.6",
     "scitex-compat==0.1.8",
-    # media now lives in figrecipe (>=0.29.0); scitex-etc retains only count_grids/yield_grids/search.
-    # See the figrecipe pin below — needs bumping to 0.29.0 to bring in the media submodule.
-    "scitex-etc==0.2.0",
+    # scitex-etc owns count_grids/yield_grids/search and the media submodule
+    # (ADR-0001 executed): scitex.media re-exports scitex_etc.media.
+    "scitex-etc>=0.3.0",
     "scitex-genai==0.1.0",
     "scitex-gists==0.1.7",
     "scitex-audit==0.1.7",
@@ -100,7 +100,6 @@ dependencies = [
     "scitex-os==0.1.7",
     "scitex-security==0.1.4",
     "scitex-tex==0.1.7",
-    "figrecipe>=0.29.0",  # scitex.media re-exports figrecipe.media (Phase B reroute).
     "scitex-ui==0.5.1",
 ]
 
@@ -355,11 +354,10 @@ gen = [
     # "torch",
 ]
 
-# Etc Module - Miscellaneous utilities
+# Etc Module - Miscellaneous utilities (count_grids, yield_grids, search, media)
 # Use: pip install scitex[etc]
 etc = [
-    "readchar",
-    "scitex-etc==0.2.0",
+    "scitex-etc>=0.3.0",
 ]
 
 # Events Module - Event system
@@ -442,9 +440,8 @@ logging = [
 ]
 
 # Media Module - Media display utilities. scitex.media re-exports
-# figrecipe.media (shipped in figrecipe >=0.29.0) — Phase B reroute
-# per operator decision, replaces scitex-python ADR-0001 (-> scitex-etc).
-# figrecipe is already a core dep so this extra is a no-op shortcut.
+# scitex_etc.media (shipped in scitex-etc >=0.3.0) — ADR-0001 executed.
+# scitex-etc is already a core dep so this extra is a no-op shortcut.
 media = []
 
 # ML Module - Machine learning
@@ -537,7 +534,7 @@ plt = [
     "pyyaml",
     "joblib",
     "ruamel.yaml",
-    "figrecipe>=0.29.0",  # scitex.media re-exports figrecipe.media (Phase B reroute).
+    "figrecipe>=0.16.0",
 ]
 
 # Project Module - Project management (OPTIONAL peer: scitex-hub.project)
@@ -838,7 +835,7 @@ dev = [
     "crossref-local",
     "csv2latex",
     "feedparser",
-    "figrecipe>=0.29.0",  # scitex.media re-exports figrecipe.media (Phase B reroute).
+    "figrecipe>=0.16.0",
     "flask>=2.0.0",
     "geom_median",
     "GitPython",
@@ -929,7 +926,7 @@ dev = [
     "scitex-container==0.2.1",
     "scitex-dataset==0.3.10",
     "scitex-dev==0.17.4",
-    "scitex-etc==0.2.0",
+    "scitex-etc>=0.3.0",
     "scitex-genai==0.1.0",
     "scitex-io==0.2.20",
     "scitex-notification==0.2.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,9 @@ dependencies = [
     "scitex-path==0.1.7",
     "scitex-repro==0.1.6",
     "scitex-compat==0.1.8",
-    "scitex-etc==0.2.0",  # media shipped here; scitex.media re-exports scitex_etc.media
+    # media now lives in figrecipe (>=0.29.0); scitex-etc retains only count_grids/yield_grids/search.
+    # See the figrecipe pin below — needs bumping to 0.29.0 to bring in the media submodule.
+    "scitex-etc==0.2.0",
     "scitex-genai==0.1.0",
     "scitex-gists==0.1.7",
     "scitex-audit==0.1.7",
@@ -98,7 +100,7 @@ dependencies = [
     "scitex-os==0.1.7",
     "scitex-security==0.1.4",
     "scitex-tex==0.1.7",
-    "figrecipe==0.28.20",
+    "figrecipe>=0.29.0",  # scitex.media re-exports figrecipe.media (Phase B reroute).
     "scitex-ui==0.5.1",
 ]
 
@@ -439,8 +441,10 @@ logging = [
     "scitex-logging==0.1.7",
 ]
 
-# Media Module - Media display utilities (always available: scitex-etc is a
-# core dep). scitex.media re-exports scitex_etc.media (shipped in >=0.2.0).
+# Media Module - Media display utilities. scitex.media re-exports
+# figrecipe.media (shipped in figrecipe >=0.29.0) — Phase B reroute
+# per operator decision, replaces scitex-python ADR-0001 (-> scitex-etc).
+# figrecipe is already a core dep so this extra is a no-op shortcut.
 media = []
 
 # ML Module - Machine learning
@@ -533,7 +537,7 @@ plt = [
     "pyyaml",
     "joblib",
     "ruamel.yaml",
-    "figrecipe==0.28.20",
+    "figrecipe>=0.29.0",  # scitex.media re-exports figrecipe.media (Phase B reroute).
 ]
 
 # Project Module - Project management (OPTIONAL peer: scitex-hub.project)
@@ -834,7 +838,7 @@ dev = [
     "crossref-local",
     "csv2latex",
     "feedparser",
-    "figrecipe==0.28.20",
+    "figrecipe>=0.29.0",  # scitex.media re-exports figrecipe.media (Phase B reroute).
     "flask>=2.0.0",
     "geom_median",
     "GitPython",

--- a/src/scitex/__init__.py
+++ b/src/scitex/__init__.py
@@ -161,8 +161,8 @@ compat = _LazyModule("compat", external="scitex_compat")  # Compatibility utilit
 audit = _LazyModule("audit", external="scitex_audit")  # Security auditing
 events = _LazyModule("events", external="scitex_events")  # Event system
 media = _LazyModule(
-    "media", external="scitex_etc.media"
-)  # in-tree dir removed; shipped in scitex-etc (>=0.2.0)
+    "media", external="figrecipe.media"
+)  # in-tree dir removed; shipped in figrecipe (>=0.29.0) — operator-confirmed Phase B reroute, replaces ADR-0001 (-> scitex-etc).
 # `project` is an OPTIONAL peer proxying scitex_hub.project (scitex-hub is NOT a
 # hard dep). A missing scitex-hub raises a friendly install hint on first access.
 project = _LazyModule("project", external="scitex_hub.project")

--- a/src/scitex/__init__.py
+++ b/src/scitex/__init__.py
@@ -161,8 +161,8 @@ compat = _LazyModule("compat", external="scitex_compat")  # Compatibility utilit
 audit = _LazyModule("audit", external="scitex_audit")  # Security auditing
 events = _LazyModule("events", external="scitex_events")  # Event system
 media = _LazyModule(
-    "media", external="figrecipe.media"
-)  # in-tree dir removed; shipped in figrecipe (>=0.29.0) — operator-confirmed Phase B reroute, replaces ADR-0001 (-> scitex-etc).
+    "media", external="scitex_etc.media"
+)  # in-tree dir removed; shipped in scitex-etc (>=0.3.0) — ADR-0001 executed.
 # `project` is an OPTIONAL peer proxying scitex_hub.project (scitex-hub is NOT a
 # hard dep). A missing scitex-hub raises a friendly install hint on first access.
 project = _LazyModule("project", external="scitex_hub.project")

--- a/src/scitex/re_export.py
+++ b/src/scitex/re_export.py
@@ -245,7 +245,7 @@ EXTERNAL_REEXPORTS = {
     "ml": "scitex_ml",
     "genai": "scitex_genai",
     "etc": "scitex_etc",
-    "media": "figrecipe.media",  # in-tree dir removed; shipped in figrecipe (>=0.29.0) — operator-confirmed Phase B reroute, replaces ADR-0001 (-> scitex-etc).
+    "media": "scitex_etc.media",  # in-tree dir removed; shipped in scitex-etc (>=0.3.0) — ADR-0001 executed.
     "gists": "scitex_gists",
     "audit": "scitex_audit",
     "compat": "scitex_compat",

--- a/src/scitex/re_export.py
+++ b/src/scitex/re_export.py
@@ -245,7 +245,7 @@ EXTERNAL_REEXPORTS = {
     "ml": "scitex_ml",
     "genai": "scitex_genai",
     "etc": "scitex_etc",
-    "media": "scitex_etc.media",  # in-tree dir removed; shipped in scitex-etc (>=0.2.0)
+    "media": "figrecipe.media",  # in-tree dir removed; shipped in figrecipe (>=0.29.0) — operator-confirmed Phase B reroute, replaces ADR-0001 (-> scitex-etc).
     "gists": "scitex_gists",
     "audit": "scitex_audit",
     "compat": "scitex_compat",


### PR DESCRIPTION
## Summary

Repoint `scitex.media` from `figrecipe.media` (the previous PR draft's
target) back to `scitex_etc.media` — ADR-0001 executed (operator
decision, 2026-06-07).

`scitex.media` is media-reference detection/display for chat-pane /
terminal / markdown targets (`render.classify`, `render.detect`,
`render.show`, plus a CLI and an MCP server). It is **not**
figure-rendering. The previous draft routed it to **figrecipe**
(figure-recipe / scientific plotting), which is the wrong semantic
home. That draft is reverted in this PR; figrecipe PR #161 is now
closed.

## Changes

- `src/scitex/__init__.py`: `_LazyModule("media", external=...)`
  flipped from `figrecipe.media` back to `scitex_etc.media`.
- `src/scitex/re_export.py`: `_DEFAULT_BRANDED["media"]` flipped
  from `figrecipe.media` to `scitex_etc.media`.
- `pyproject.toml`:
  - Drop the `figrecipe>=0.29.0` bumps at the three pin sites
    (top-level core deps, `[plt]` extra, `[dev]` extra). figrecipe
    goes back to its pre-PR pin `>=0.16.0` (it remains a core dep
    via `figrecipe.diagram` etc.).
  - `scitex-etc` pin moves to `>=0.3.0` at all 3 sites (top-level
    core deps, `[etc]` extra, `[all,dev]` aggregate).
  - `[etc]` extra drops the legacy `readchar` (it was only used by
    the retired `wait_key` surface).
- `docs/adr/0001-relocate-media-to-scitex-etc.md`: status flipped
  from "Superseded (figrecipe routing)" to **Executed** — the ADR's
  original conclusion (`scitex-etc`) is what shipped.
- `CHANGELOG.md`: rewritten Unreleased entry.

## Merge sequencing

This PR cannot be merged until `scitex-etc 0.3.0` is on PyPI
(otherwise the `>=0.3.0` pin will fail to resolve). Track:

- scitex-etc PR #24: https://github.com/ywatanabe1989/scitex-etc/pull/24
- figrecipe PR #161: **closed** (rejected re-route).

## Test plan

- [ ] CI green.
- [ ] `import scitex; scitex.media.render.classify("x.png")` works
  end-to-end against `scitex-etc>=0.3.0`.
- [ ] ADR-0001 reachable from the docs index and shows **Executed**.

I have read and agree to the SciTeX CLA.
