### PR TITLE
chore(deps): bump scitex-dev pin to >=0.17.8 (stop CI flood)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     # App SDK — unified file storage for local + cloud
     "scitex-app==0.2.8",
     # Delegated core modules (thin re-exports)
-    "scitex-dev==0.17.4",
+    "scitex-dev>=0.17.8",
     "scitex-io==0.2.20",
     "scitex-stats==0.2.23",
     "scitex-audio==0.2.13",
@@ -931,7 +931,7 @@ dev = [
     # `pip install scitex[cloud]` when scitex-hub is available.
     "scitex-container==0.2.1",
     "scitex-dataset==0.3.10",
-    "scitex-dev==0.17.4",
+    "scitex-dev>=0.17.8",
     "scitex-etc==0.2.0",
     "scitex-genai==0.1.0",
     "scitex-io==0.2.20",
@@ -1067,7 +1067,7 @@ all = [
 # ============================================
 # Tool Configurations
 # ============================================
-linter = ["scitex-dev==0.17.4"]
+linter = ["scitex-dev>=0.17.8"]
 orochi = ["scitex-orochi==0.16.4"]
 agent-container = ["scitex-agent-container==0.21.9"]
 


### PR DESCRIPTION
## Summary

Stops the umbrella's daily CI red-email flood by bumping the `scitex-dev` pin to pick up the warn-only PS-170 behaviour shipped in scitex-dev 0.17.8 (2026-06-09 12:07 UTC).

**Root cause:** The umbrella's `tests` workflow runs `scitex-dev ecosystem audit-umbrella-pins .` on every push / nightly cron. With `scitex-dev==0.17.4` pinned here, CI installs the 0.17.4 binary — which has the pre-0.17.8 *strict-error* PS-170 behaviour and exits 1 the moment any leaf publishes a newer wheel ahead of the umbrella's `==` pin. Result: ~12 ecosystem CI reds in a single morning on 2026-06-09.

**Fix:** Bump to `scitex-dev>=0.17.8` in all three pin sites:

- `[project].dependencies` (line 71)
- `[project].optional-dependencies.dev` (line 934)
- `[linter]` optional-deps mount (line 1070)

scitex-dev 0.17.8 (https://github.com/ywatanabe1989/scitex-dev/pull/146) made PS-170 warn-only by default: `audit-umbrella-pins .` now prints `WARN:` lines to stderr and exits 0, so an upstream leaf release no longer cascades into red CI. Pass `--strict` to restore the pre-0.17.8 fail-on-drift behaviour for the release-pipeline pre-publish gate.

## Test plan

- [ ] CI tests workflow (the matrix that was failing on the umbrella pin step) turns green.
- [ ] Operator stops receiving the daily ecosystem CI-red email.

## Notes

- **NOT auto-merged.** This is the operator-SSoT repo; leaving the merge decision to the operator (lead-confirmed flow).
- Lead a2a context: `89b7bdd955534e008fadfe98970d4a7f` (proj-scitex-dev → lead, 2026-06-09).
- Sibling PRs (consumer quality-audit workflow template fixes) coming separately for scitex-stats / scitex-clew / scitex-audio / scitex-app / scitex-notebook / scitex-scholar / etc.
