### PR TITLE
chore: gitignore .worktrees/ (agent worktree churn)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -956,3 +956,4 @@ src/scitex/_sphinx_html/
 .venv/
 # Claude worktree symlink
 /feat-enhance-interface_04_skills
+.worktrees/


### PR DESCRIPTION
Agent worktree-isolation creates <repo>/.worktrees/, which was NOT gitignored -> perpetual dirty tree -> pre-stop rescue-autosave commits pollute develop (fleet-wide, blocked deploy-freshness ff-pull). Adds .worktrees/ to .gitignore. Operator-approved 2026-07-08 (per-repo, option B).