### PR TITLE
fix(tests): drop a cross-package import that has silently skipped since io 0.3.0

### DIFF
--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -165,7 +165,6 @@ CROSS_PACKAGE_IMPORTS = [
     "scitex_io._load_modules._pandas",
     "scitex_io._load_modules._pdf",
     "scitex_io._load_modules._pickle",
-    "scitex_io._load_modules._sqlite3",
     "scitex_io._load_modules._torch",
     "scitex_io._load_modules._txt",
     "scitex_io._load_modules._xml",


### PR DESCRIPTION
fix(tests): drop a cross-package import that has silently skipped since io 0.3.0

`scitex_io._load_modules._sqlite3` is in the parametrized list of cross-package
modules that `test_cross_package_import` walks. That module was DELETED in
scitex-io 0.3.0 and does not exist on origin/develop today.

It does not fail. The test body calls
`_import_or_skip_if_snapshot_drifted(module_name)`, so an absent module SKIPS and
the case reports green. It has been reporting green while checking nothing for as
long as the module has been gone.

That is the shape this fleet keeps finding: a gate that cannot fail. It is the
same class as PS-140 in scitex-io — `importorskip` on the FULL path, so a renamed
or deleted submodule silently skips rather than surfacing — which was fixed there
this week with a negative control proving the pre-fix case SKIPPED (green) and the
post-fix case FAILED.

Removing the entry costs nothing and is honest: the module is gone, so there is no
cross-package import to assert. The remaining entries in that list are unaffected.

Incidentally this is also the last occurrence of the string in this file, and one
of only three in the whole repository, the other two being a stdlib module-name
list and an assertion about `scitex-db`'s public `SQLite3` class — scitex-db being
the operator's one granted exemption, a database LIBRARY rather than SciTeX state.
