### PR TITLE
ci(tests): read vars.CI_RUNS_ON, with ubuntu-latest as the fallback

### DIFF
--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -12,7 +12,14 @@ on:
 jobs:
   test:
     name: pytest-matrix-on-ubuntu-py${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    # Consult the repo-level CI_RUNS_ON variable so this matrix can be pointed at
+    # our own hardware (label set `scitex-org-cpu`, hosts compute-01/03/04)
+    # without editing the workflow. The variable holds a JSON array of labels,
+    # e.g. '["self-hosted","Linux","X64","scitex-org-cpu"]'. Where it is UNSET the
+    # literal fallback applies and nothing changes: ubuntu-latest, exactly as
+    # before. Until 2026-08-31 this line hardcoded ubuntu-latest, so setting the
+    # variable was silently ignored — the write landed, the runs did not move.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '["ubuntu-latest"]') }}
     # Ceiling well below the GitHub-Actions 6h maximum so a genuine hang
     # (wedged subprocess / coverage deadlock — the old chronic "tests" red)
     # fails fast and diagnosably. The suite itself is single-digit minutes


### PR DESCRIPTION
## The problem

The repository variable `CI_RUNS_ON` was set on this repo to point CI at our own
hardware. It changed nothing, because the `tests` workflow never READ it — the job
hardcoded `runs-on: ubuntu-latest`. The variable write was verified; the effect was
not. A rerun still landed on a GitHub-hosted runner ("GitHub Actions 1000048594",
16m57s).

## What now consults it

`.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml`, job `test`:

```yaml
runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '["ubuntu-latest"]') }}
```

Same pattern already proven in `scitex-agent-container`, whose jobs demonstrably
run on `scitex-0X-org-cpu-01`.

- Where `CI_RUNS_ON` is SET (currently `["self-hosted","Linux","X64","scitex-org-cpu"]`),
  the matrix runs on our compute pool.
- Where it is UNSET (a fork, a clone, any repo that never got the variable), the
  literal `'["ubuntu-latest"]'` fallback applies and behaviour is byte-for-byte what
  it was.

No other job or workflow is touched; nothing else in the file changes.

## Verification

The point of this change is the landing runner, not the diff. This PR's own `tests`
run is the check: `gh api repos/scitex-ai/scitex-python/actions/runs/<id>/jobs --jq
'.jobs[]|"\(.runner_name) \(.name) \(.conclusion)"'` must report
`scitex-0X-org-cpu-01`, not `GitHub Actions NNNN`.
