### PR TITLE
fix(helpers): decide optional-dep availability from the spec, not by importing

### DIFF
--- a/src/scitex/helpers/_optional_deps.py
+++ b/src/scitex/helpers/_optional_deps.py
@@ -14,6 +14,7 @@ Multiple modules:
 """
 
 import importlib
+import importlib.util  # `import importlib` alone does not bind the submodule
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 F = TypeVar("F", bound=Callable[..., Any])
@@ -195,30 +196,69 @@ def optional_import(
         raise ImportError(error_msg)
 
 
+def _is_installed(module_name: str) -> bool:
+    """
+    Report whether ``module_name`` can be located, WITHOUT executing it.
+
+    ``importlib.util.find_spec`` asks the finders on ``sys.meta_path`` where a
+    module lives and stops there; it never runs the module's top-level code.
+    Mirrors the handling already proven in ``scitex.re_export``.
+
+    Args:
+        module_name: Import name of the module (e.g. 'torch', 'ruamel.yaml')
+
+    Returns
+    -------
+        True if the module is installed, False otherwise
+    """
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except (ImportError, AttributeError, ValueError):
+        # ModuleNotFoundError (an ImportError subclass): a dotted name whose
+        # PARENT package is absent -- find_spec raises rather than returning
+        # None. AttributeError: a parent that is not a package. ValueError:
+        # the name is already in sys.modules with __spec__ set to None.
+        # All three mean "not usable as an import target".
+        return False
+
+
 def check_optional_deps(*module_names: str) -> Dict[str, bool]:
     """
-    Check which optional dependencies are available.
+    Check which optional dependencies are INSTALLED.
+
+    Availability is resolved from each module's spec, without executing the
+    module. Importing a package merely to discover that it exists runs
+    arbitrary third-party code inside what callers reasonably expect to be a
+    cheap predicate. That has three costs this function used to pay:
+
+    - it loads the dependency and every C extension underneath it into the
+      calling process, purely as a side effect of asking a question;
+    - it is slow (importing torch to answer "is torch installed" takes
+      seconds);
+    - it can fail in ways an availability probe must never propagate. The old
+      body caught only ``ImportError``, so probing the ``dsp`` module -- whose
+      ``sounddevice`` dependency raises ``OSError('PortAudio library not
+      found')`` on a host without PortAudio -- did not return False, it
+      crashed the caller.
 
     Args:
         *module_names: Names of modules to check
 
     Returns
     -------
-        Dictionary mapping module names to availability (True/False)
+        Dictionary mapping module names to installed-ness (True/False)
+
+    Note:
+        This answers "is it installed", not "does it import cleanly". A
+        package that is present but raises at import time reports True here.
+        Use :func:`optional_import` when you need the module object itself.
 
     Example:
         >>> available = check_optional_deps('torch', 'transformers')
         >>> if available['torch']:
-        ...     import torch
+        ...     import torch  # may still raise if the install is broken
     """
-    result = {}
-    for name in module_names:
-        try:
-            importlib.import_module(name)
-            result[name] = True
-        except ImportError:
-            result[name] = False
-    return result
+    return {name: _is_installed(name) for name in module_names}
 
 
 def get_install_command(module_name: str) -> str:

--- a/tests/scitex/helpers/test__optional_deps.py
+++ b/tests/scitex/helpers/test__optional_deps.py
@@ -9,6 +9,7 @@ in a downstream project. No mocks — every probe runs against the real env.
 """
 
 import importlib
+import sys
 
 import pytest
 
@@ -86,6 +87,97 @@ def test_check_optional_deps_runs_without_error():
     result = fn()
     # Assert
     assert result is None or isinstance(result, (dict, list, bool))
+
+
+def test_check_optional_deps_maps_names_to_installed_state():
+    # Arrange — one name that is always installed, one that never is
+    names = ("numpy", "scitex_definitely_missing_pkg_xyz")
+    # Act
+    result = od.check_optional_deps(*names)
+    # Assert
+    assert result == {"numpy": True, "scitex_definitely_missing_pkg_xyz": False}
+
+
+def test_check_optional_deps_values_are_plain_bools():
+    # Arrange — `has_stats` compares the returned dict to a {name: True}
+    # literal, so values must be bools, not truthy ModuleSpec objects.
+    names = ("numpy", "scitex_definitely_missing_pkg_xyz")
+    # Act
+    result = od.check_optional_deps(*names)
+    # Assert
+    assert all(type(value) is bool for value in result.values())
+
+
+def _install_real_package(root, name, body):
+    """Write a real importable package under ``root`` and put it on sys.path."""
+    pkg = root / name
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text(body)
+    sys.path.insert(0, str(root))
+    return pkg
+
+
+@pytest.fixture
+def side_effect_package(tmp_path):
+    """A REAL importable package that records having had its body executed."""
+    sentinel = tmp_path / "executed.marker"
+    name = "scitex_probe_side_effect_pkg"
+    _install_real_package(
+        tmp_path,
+        name,
+        "from pathlib import Path\nPath(%r).write_text('executed')\n" % str(sentinel),
+    )
+    yield name, sentinel
+    sys.path.remove(str(tmp_path))
+    sys.modules.pop(name, None)
+
+
+def test_check_optional_deps_does_not_execute_the_module(side_effect_package):
+    # Arrange — probing availability must never run third-party top-level
+    # code: in CI that walk imported the whole optional stack (233 C
+    # extensions) into the pytest process just to answer "is it installed".
+    name, sentinel = side_effect_package
+    # Act
+    od.check_optional_deps(name)
+    # Assert
+    assert not sentinel.exists(), "availability probe executed the module body"
+
+
+def test_check_optional_deps_finds_package_without_executing_it(side_effect_package):
+    # Arrange
+    name, _sentinel = side_effect_package
+    # Act
+    result = od.check_optional_deps(name)
+    # Assert
+    assert result == {name: True}
+
+
+def test_check_optional_deps_reports_installed_package_that_raises_on_import(tmp_path):
+    # Arrange — a REAL installed package whose import raises a non-ImportError,
+    # exactly like `sounddevice` raising OSError('PortAudio library not found')
+    # on a host without PortAudio. The probe must answer, not propagate.
+    name = "scitex_probe_raises_pkg"
+    _install_real_package(
+        tmp_path, name, "raise OSError('PortAudio library not found')\n"
+    )
+    try:
+        # Act
+        result = od.check_optional_deps(name)
+        # Assert — installed is the honest answer; it is on disk and locatable
+        assert result == {name: True}
+    finally:
+        sys.path.remove(str(tmp_path))
+        sys.modules.pop(name, None)
+
+
+def test_check_optional_deps_reports_false_for_dotted_name_with_missing_parent():
+    # Arrange — find_spec RAISES ModuleNotFoundError for an absent parent
+    # package rather than returning None; that must read as "not installed".
+    name = "scitex_definitely_missing_pkg_xyz.submodule"
+    # Act
+    result = od.check_optional_deps(name)
+    # Assert
+    assert result == {name: False}
 
 
 # EOF


### PR DESCRIPTION
## What

`check_optional_deps` decided "is this dependency installed?" by calling
`importlib.import_module(name)` — executing the dependency's top-level code
just to learn that it exists. This switches the **availability** path to
`importlib.util.find_spec`, which resolves the module's spec from
`sys.meta_path` without running it. The **loader** path (`optional_import`,
which actually returns the module) is unchanged.

## Why — the measurement

Walking `MODULE_REQUIREMENTS` once is what `check_module_deps`,
`require_module`, `show_install_guide` and the install-guide tests all do.
Measured against this repo's own `.venv`:

| | modules loaded | C extensions loaded |
|---|---|---|
| before | 5912 | 233 |
| after | 1 | 0 |

That is the reachability path to the py3.13 SIGSEGV. CI job `99189761473`
(`pytest-matrix-on-ubuntu-py3.13`) died in

```
Garbage-collecting
  typing.py:1031 in __init__          <- ForwardRef.__init__, the compile() call
  typing_extensions.py:1233 in __new__ <- TypedDict _type_check
  openai/types/responses/response_compaction_item_param_param.py:11 in <module>
```

in a process holding **199 C extensions**. On CPython 3.13.15 with
openai 3.6.0, driving `check_module_deps("ai")`:

```
BEFORE  OPENAI_MODULE_BODY_EXECUTED=True   CI_CRASH_SITE_MODULE_LOADED=True
AFTER   OPENAI_MODULE_BODY_EXECUTED=False  CI_CRASH_SITE_MODULE_LOADED=False
```

The returned answer is byte-identical before and after
(`{'available': False, 'missing': ['anthropic'], ...}`).

### A second, fully reproducible bug fixed on the way

The old body caught **only** `ImportError`. A package that is installed but
raises anything else did not report `False` — it crashed the caller. Probing
the `dsp` module on a host without PortAudio:

```
File ".../scitex/helpers/_optional_deps.py", line 217, in check_optional_deps
    importlib.import_module(name)
File ".../sounddevice.py", line 73, in <module>
    raise OSError('PortAudio library not found')
OSError: PortAudio library not found
```

exit code **1** before this change, **0** after.

## Honest scope — this is not proven to unblock CI on its own

Reading all three retry attempts in job `99189761473`:

- **attempt 1** — segfault in the openai import chain, at
  `tests/scitex/helpers/test__install_guide.py`. This PR removes that site.
- **attempt 2** — segfault in `_pytest/nodes.py:286 iter_parents`, at
  `tests/integration/test_integration.py::TestDelegatedModules::test_dict_dotdict_works`.
  No openai in the stack.
- **attempt 3** — identical to attempt 2.

All three are `Garbage-collecting` crashes in a 199-extension process, which
matches the non-determinism the workflow file already documents. So this PR
removes one confirmed crash site and cuts 233 C extensions out of the test
process — it addresses the mechanism, but attempts 2/3 crashed elsewhere and
may recur.

I could **not** reproduce the 3.13 segfault locally. Harness was calibrated
first (`ctypes.string_at(0)` → 139, clean exit → 0 on the same interpreter);
bare `import openai`, `gc.set_threshold(1,1,1)`, and recursion depths to 15000
all exited 0.

## Semantics changed

Now answers **"is it installed"**, not **"does it import cleanly"**. A package
present but broken at import reports `True`.

- `require_module` / `warn_module_deps` — gate on installed-ness; a broken
  install now surfaces the upstream traceback rather than the friendly
  `pip install scitex[...]` message. Weighed against the old behaviour, which
  propagated `OSError` out of a boolean probe, this is a net improvement.
- `show_install_guide` — strictly more correct; its label literally reads
  "Installed", and it no longer imports torch to print a status table.
- `has_deep_learning` / `has_transformers` / `has_audio` / `has_stats` /
  `has_io` / `has_plotting` / `has_mcp` / `has_scholar` / `has_jupyter` —
  feature-detection probes, same shift.
- **Deliberately unchanged:** the `requires` decorator
  (`_install_guide.py:193`) keeps `import_module`. It guards a function that
  is about to *use* the package, so "imports cleanly" is the honest question
  there. Flagging that `@requires` and `require_module` can now disagree about
  a broken install.
- `optional_import` (the loader) and `check_mcp_deps` — untouched.

`check_optional_deps` is public API (`scitex.helpers.__all__`), so this is a
behaviour change, not an internal refactor.

## Tests

Four regression tests, real packages written to disk, **no mocks**:

- probe does not execute the module body (sentinel file stays absent)
- probe locates such a package (`True`) without running it
- an installed-but-raising package reports `True` instead of propagating —
  pins the `sounddevice` bug
- a dotted name with a missing parent reports `False` — `find_spec` raises
  rather than returning `None` there

`27 passed` across `test__optional_deps.py`, `test__install_guide.py`,
`test___init__.py`, no skips.

## Not done

Not fixed by skipping the test, pinning away from 3.13, or disabling GC.

Pre-existing bug found but left alone: `MODULE_REQUIREMENTS` mixes pip names
with import names — `pyyaml` is not importable (the module is `yaml`), so
`config` / `diagram` / `session` report `available: False` permanently under
both implementations.
