### PR TITLE
chore(deps): scitex-clew ==0.17.0 -> >=0.20.0 — let the PostgreSQL migration arrive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ dependencies = [
     # Config + env loading (scitex.helpers.load_scitex_env delegates here)
     "scitex-config==0.3.6",
     # Reproducibility Verification
-    "scitex-clew==0.17.0",
+    "scitex-clew>=0.20.0",
     # App SDK — unified file storage for local + cloud
     "scitex-app==0.2.11",
     # Delegated core modules (thin re-exports)
@@ -793,7 +793,7 @@ web = [
 # Clew Module - Hash-based verification for reproducible science (Ariadne's thread)
 # Use: pip install scitex[clew]
 # Note: No extra dependencies - uses only the standard library
-clew = ["scitex-clew==0.17.0"]
+clew = ["scitex-clew>=0.20.0"]
 
 # Writer Module - Academic paper writing
 # Use: pip install scitex[writer]
@@ -948,7 +948,7 @@ dev = [
     "scitex-audio==0.3.0",
     "scitex-audit==0.2.0",
     "scitex-browser==0.1.15",
-    "scitex-clew==0.17.0",
+    "scitex-clew>=0.20.0",
     # NOTE: scitex-hub (optional peer powering cloud/module/project; formerly
     # scitex-cloud) is intentionally NOT in [dev] — it is unreleased, so listing
     # it here would break CI's `.[all,dev]` resolve. Install explicitly via


### PR DESCRIPTION
Moves `scitex-clew` from an exact pin to a floor, so the PostgreSQL store migration actually reaches this package.

**Why this was the last SQLite item.** scitex-python pinned `scitex-clew==0.17.0` in three places. That tag is dated **2026-07-06**, nearly two months before clew migrated its stores off the embedded engine (`4f20c97` on 08-28, `416f42f`/#151 on 08-30). So running this package's suite re-created `.scitex/clew/runtime/clew.db` — 84 KB, first sixteen bytes `SQLite format 3` — even though clew's own `develop` had been clean for days. The exact pin froze a July build for two months and silently kept the retired engine alive.

**The floor, not a bump.** An exact pin is what caused this: it cannot pick up a fix without a human editing three lines. `>=0.20.0` lets the migration arrive on its own, and is the shape the operator asked for when he raised it (「フロアをピンするだけのほうがいいのかなぁ」).

**0.20.0 is verified at the ARTIFACT, not the version string** — the trap that started this whole investigation was `0.19.1` looking newer than the work it lacked. Downloaded `scitex_clew-0.20.0-py3-none-any.whl` from PyPI and inspected it:

- `_db/_core.py` imports `scitex_dev.store` — **yes**
- `_db/_core.py` imports `sqlite3` — **no**
- `.py` files importing the engine anywhere in the wheel — **0**

Three call sites updated: lines 82, 796, 951.
