### PR TITLE
ci(cla): add the push trigger scitex-io's caller has

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -47,6 +47,14 @@ on:
     types: [created]
   pull_request_target:
     types: [opened, closed, synchronize]
+  # Missing until now — scitex-io (the mirrored reference) has it. Without a
+  # `push` trigger the reusable's `owner-bypass` job (marks CLAssistant=success
+  # on the owner's direct push, since a direct push has no PR to sign against)
+  # never runs here, and a `git push` to main/develop by the repo owner sits
+  # with no CLAssistant status at all rather than an owner-bypass success.
+  push:
+    branches: [main, develop]
+    tags: ['v*']
 
 permissions:
   actions: write


### PR DESCRIPTION
## Summary

- `.github/workflows/cla.yml` already delegates to the org reusable
  workflow (`scitex-ai/.github/.github/workflows/cla.yml`, merged via
  #367) but its `on:` block dropped the `push` trigger that scitex-io's
  caller (the file this migration was told to mirror) has. Without it
  the reusable's `owner-bypass` job never fires on a direct push by the
  allowlisted owner.
- Adds `push: { branches: [main, develop], tags: ['v*'] }`, matching
  scitex-io byte-for-byte on that block.
- `permissions:`, `default_branch` (main), `runs_on`, and the
  `owner_allowlist`/secret mapping were already correct on `develop`
  (a prior session's #367 already did the reusable-workflow migration
  properly, including SHA-pinning the callee and carrying over the
  `LLEmacs` allowlist entry) — this PR only adds the missing trigger.

## IMPORTANT — this alone will NOT turn the live CLA check green

Verified empirically: GitHub resolves the workflow YAML for
`pull_request_target` (and `issue_comment`) from the repository's
**default branch**, not the PR's base branch — confirmed against
GitHub's own docs ("This event runs in the context of the default
branch of the base repository"). scitex-python's default branch is
`main`, and `main` still has the old, fully inline
`contributor-assistant/github-action@v2.6.1` config pointing at the
deleted `cla-signatures` branch. `develop` has had the correct
reusable-workflow config since #367 merged (2026-08-30), yet every
CLA run since — on PRs based on develop, including this one — still
executes the old `main` config and fails with the same
`Branch cla-signatures not found` error. Landing this on `develop`
does not change that; `main` needs the fix too (see PR #360,
"promote develop → main", open since 2026-08-10).

## Test plan

- [x] YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`.
- [ ] Confirm this PR's own CLAssistant check conclusion once CI runs (expected to still fail, for the default-branch reason above).
